### PR TITLE
Remove proceeding slash from Copy Relative Path - Fixes #6

### DIFF
--- a/PathTools.py
+++ b/PathTools.py
@@ -96,7 +96,7 @@ class CopyRelativePathCommand(sublime_plugin.TextCommand):
         self.path = self.view.file_name()
         for folder in projectFolders:
             if folder in self.view.file_name():
-                self.path = self.path.replace(folder, '')
+                self.path = self.path.replace(folder, '')[1:]
                 break
         sublime.set_clipboard(self.path)
         sublime.status_message("Copied file directory: %s" % self.path)


### PR DESCRIPTION
The fix really couldn't be simpler.